### PR TITLE
Feat/add callback support

### DIFF
--- a/.readme.mjs
+++ b/.readme.mjs
@@ -1,4 +1,4 @@
-import { Logger } from "./dist/logger-class.js";
+import { Logger } from "./dist/esm/logger-class.js";
 
 const logger = new Logger();
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 
-import { selectLevel } from "../helpers";
-import { LogLevel } from "../models";
+import { selectLevel, selectMode } from "../helpers";
+import { LogLevel, ServerMode } from "../models";
 
 export const LOG_LEVEL =
   process.env.NODE_ENV == "test" ? LogLevel.TRACE : selectLevel((process.env.LOG_LEVEL ?? "info").toLowerCase());
@@ -11,4 +11,5 @@ export const LOG_EXPANDED =
   (process.env.LOG_EXPANDED && process.env.LOG_EXPANDED == "true") ||
   (process.env.NODE_ENV && process.env.NODE_ENV == "test") ||
   false;
-export const LOG_SERVER_MODE = (process.env.LOG_MODE && process.env.LOG_MODE == "server") || false;
+export const LOG_SERVER_MODE = process.env.LOG_MODE ? selectMode(process.env.LOG_MODE) : ServerMode.OFF;
+export const LOG_OBJECT_DEPTH = Number(process.env.LOG_DEPTH) ?? 6;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,6 +1,7 @@
 export * from "./log-expand";
 export * from "./log-items";
 export * from "./log-level";
+export * from "./log-mode";
 export * from "./log-object";
 export * from "./log-prefix";
 export * from "./log-support";

--- a/src/helpers/log-expand.ts
+++ b/src/helpers/log-expand.ts
@@ -1,5 +1,6 @@
 import inspect from "browser-util-inspect";
 
+import { LOG_OBJECT_DEPTH } from "../config";
 import { LogData } from "../models";
 import { parseData } from ".";
 
@@ -14,15 +15,16 @@ type ExpandOptions = {
  * @param data the raw data
  * @param params.expanded set true to deeply parse JSON strings in to objects before writing to output
  * @param params.browser set true to prevent the output being wrapped with `inspect` and colour output
+ * @param params.server set true to prevent `inspect` adding escaped colour commands in the log output
  * @returns formatted data
  */
 export const expand = (data: LogData, params?: ExpandOptions): LogData => {
   const { expanded = false, browser = false, server = false } = params ?? {};
   if (data && typeof data == "string" && expanded) {
-    return browser ? parseData(data) : inspect(parseData(data), false, 5, !server);
+    return browser ? parseData(data) : inspect(parseData(data), false, LOG_OBJECT_DEPTH, !server);
   }
   if (!browser && data && typeof data == "object" && Object.keys(data).length) {
-    return inspect(data, false, 5, !server);
+    return inspect(data, false, LOG_OBJECT_DEPTH, !server);
   }
   return data;
 };

--- a/src/helpers/log-mode.ts
+++ b/src/helpers/log-mode.ts
@@ -1,0 +1,18 @@
+import { ServerMode } from "../models";
+
+export const selectMode = (input: ServerMode | string | undefined): ServerMode => {
+  switch (input) {
+    case ServerMode.AWS:
+      return ServerMode.AWS;
+    case ServerMode.GCP:
+      return ServerMode.GCP;
+    case ServerMode.STD:
+    case "server":
+      return ServerMode.STD;
+    case ServerMode.OFF:
+    case "console":
+    case undefined:
+    default:
+      return ServerMode.OFF;
+  }
+};

--- a/src/helpers/log-support.ts
+++ b/src/helpers/log-support.ts
@@ -1,3 +1,6 @@
+import { LoggerCallback } from "../logger-class";
 import { LogType } from "../models";
 
 export const consoleHas = LogType.map((level) => typeof console[level] == "function");
+
+export const callbackHas = (callback: LoggerCallback) => LogType.map((level) => typeof callback[level] == "function");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { Logger } from "./logger-class";
 export { logger } from "./logger-function";
+export { LogLevel, LogObject, ServerMode } from "./models";

--- a/src/logger-class.ts
+++ b/src/logger-class.ts
@@ -17,13 +17,24 @@
  */
 
 import { LOG_BROWSER, LOG_EXPANDED, LOG_LEVEL, LOG_SERVER_MODE } from "./config";
-import { consoleHas, expand, logItems, logObject, prefix, selectLevel } from "./helpers";
-import { logger } from "./logger-function";
-import { LogData, LogExpander, LogLevel, LogType } from "./models";
+import { callbackHas, expand, logItems, logObject, prefix, selectLevel } from "./helpers";
+import { gcpSeverity, LogData, LogExpander, LogLevel, LogType, ServerMode } from "./models";
+
+export const serverModes = [ServerMode.AWS, ServerMode.GCP, ServerMode.STD];
+
+export interface LoggerCallback {
+  log: (...args: unknown[]) => void;
+  error?: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+  info?: (...args: unknown[]) => void;
+  debug?: (...args: unknown[]) => void;
+  trace?: (...args: unknown[]) => void;
+}
 
 export interface LoggerInitialization {
   correlation?: string | Record<string, unknown>;
-  serverMode?: boolean;
+  serverMode?: ServerMode;
+  serverCall?: (...args: unknown[]) => void;
   expandedMode?: boolean;
   logLimit?: number;
   expander?: LogExpander;
@@ -31,26 +42,34 @@ export interface LoggerInitialization {
 
 export class Logger {
   private browser: boolean = LOG_BROWSER;
-  private server: boolean;
+  private mode: ServerMode;
   private expanded: boolean;
   private logLimit: number;
   private correlation: Record<string, unknown> | undefined;
   private expander: LogExpander;
+  private callback: LoggerCallback;
   constructor(params?: LoggerInitialization) {
-    const { correlation, serverMode, expandedMode, logLimit, expander } = params ?? {};
-    this.server = serverMode ?? LOG_SERVER_MODE;
+    const { correlation, serverMode, serverCall, expandedMode, logLimit, expander } = params ?? {};
+    this.mode = serverMode ?? LOG_SERVER_MODE;
+    this.callback = typeof serverCall == "function" ? { log: serverCall } : console;
     this.expanded = expandedMode ?? LOG_EXPANDED;
     this.logLimit = logLimit ?? LogType.indexOf(LOG_LEVEL);
     this.correlation = typeof correlation == "string" ? { id: correlation } : correlation;
     this.expander =
-      expander ?? ((v: LogData) => expand(v, { expanded: this.expanded, browser: this.browser, server: this.server }));
+      expander ??
+      ((v: LogData) => expand(v, { expanded: this.expanded, browser: this.browser, server: this.mode !== ServerMode.OFF }));
   }
 
   private call = (logLevel: LogLevel, ...data: LogData[]): void => {
     const level = LogType.indexOf(logLevel);
     if (level <= this.logLimit) {
-      const target = consoleHas[level] ? logLevel : LogLevel.LOG;
-      if (this.server) {
+      const target = callbackHas(this.callback)[level] ? logLevel : LogLevel.LOG;
+      if (this.mode) {
+        if (this.mode == ServerMode.GCP) {
+          const metadata = { severity: gcpSeverity[logLevel], resource: { type: "global" } };
+          const logData = logObject(this.expander, level, this.correlation, ...data);
+          this.callback.log({ metadata, logData });
+        }
         console[target].apply(null, [logObject(this.expander, level, this.correlation, ...data)]);
       } else {
         const items = logItems(this.expander, level, ...data);
@@ -67,8 +86,14 @@ export class Logger {
     if (logChange) console.log(prefix(0), `logger: set to ${LogType[this.logLimit]} (${this.logLimit})`);
     return targetLevel;
   };
-  consoleSupport = logger.consoleSupport;
-  serverMode = (state: boolean) => (this.server = state);
+  consoleSupport = (): Record<LogLevel, boolean> => {
+    const support: Record<string, boolean> = {};
+    LogType.map((level, index) => {
+      support[level] = callbackHas(this.callback)[index];
+    });
+    return support;
+  };
+  serverMode = (mode: ServerMode) => (this.mode = mode);
   expandedMode = (state: boolean) => (this.expanded = state);
   setCorrelation = (values: Record<string, unknown>) => (this.correlation = { ...this.correlation, ...values });
   log = (...data: LogData[]): void => this.call(LogLevel.LOG, ...data);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,4 +1,5 @@
 export * from "./log-data";
 export * from "./log-expand";
 export * from "./log-levels";
+export * from "./log-mode";
 export * from "./log-object";

--- a/src/models/log-levels.ts
+++ b/src/models/log-levels.ts
@@ -8,12 +8,3 @@ export enum LogLevel {
 }
 
 export const LogType = [LogLevel.LOG, LogLevel.ERROR, LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG, LogLevel.TRACE];
-
-export const gcpSeverity = {
-  [LogLevel.LOG]: 0,
-  [LogLevel.ERROR]: 500,
-  [LogLevel.WARN]: 400,
-  [LogLevel.INFO]: 200,
-  [LogLevel.DEBUG]: 100,
-  [LogLevel.TRACE]: 100,
-};

--- a/src/models/log-levels.ts
+++ b/src/models/log-levels.ts
@@ -8,3 +8,12 @@ export enum LogLevel {
 }
 
 export const LogType = [LogLevel.LOG, LogLevel.ERROR, LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG, LogLevel.TRACE];
+
+export const gcpSeverity = {
+  [LogLevel.LOG]: 0,
+  [LogLevel.ERROR]: 500,
+  [LogLevel.WARN]: 400,
+  [LogLevel.INFO]: 200,
+  [LogLevel.DEBUG]: 100,
+  [LogLevel.TRACE]: 100,
+};

--- a/src/models/log-mode.ts
+++ b/src/models/log-mode.ts
@@ -1,0 +1,6 @@
+export enum ServerMode {
+  AWS = "AWS",
+  GCP = "GCP",
+  STD = "STD",
+  OFF = "",
+}

--- a/src/models/log-object.ts
+++ b/src/models/log-object.ts
@@ -1,8 +1,9 @@
 import { LogData } from "./log-data";
+import { LogLevel } from "./log-levels";
 
 export type LogObject = {
   level: number;
-  severity: string;
+  severity: LogLevel;
   correlation?: Record<string, unknown> | null;
   message: LogData[];
 };

--- a/src/tests/log-mode.spec.ts
+++ b/src/tests/log-mode.spec.ts
@@ -1,0 +1,36 @@
+import { selectMode } from "../helpers";
+import { ServerMode } from "../models";
+
+describe("selectMode", () => {
+  it("should return ServerMode.AWS when input is ServerMode.AWS", () => {
+    expect(selectMode("AWS")).toBe(ServerMode.AWS);
+  });
+
+  it("should return ServerMode.GCP when input is ServerMode.GCP", () => {
+    expect(selectMode("GCP")).toBe(ServerMode.GCP);
+  });
+
+  it("should return ServerMode.STD when input is ServerMode.STD", () => {
+    expect(selectMode("STD")).toBe(ServerMode.STD);
+  });
+
+  it('should return ServerMode.STD when input is "server"', () => {
+    expect(selectMode("server")).toBe(ServerMode.STD);
+  });
+
+  it('should return ServerMode.OFF when input is "console"', () => {
+    expect(selectMode("console")).toBe(ServerMode.OFF);
+  });
+
+  it("should return ServerMode.OFF when input is ServerMode.OFF", () => {
+    expect(selectMode("")).toBe(ServerMode.OFF);
+  });
+
+  it("should return ServerMode.OFF when input is an unknown string", () => {
+    expect(selectMode("unknown")).toBe(ServerMode.OFF);
+  });
+
+  it("should return ServerMode.OFF when input is undefined", () => {
+    expect(selectMode(undefined)).toBe(ServerMode.OFF);
+  });
+});

--- a/src/tests/log-support.spec.ts
+++ b/src/tests/log-support.spec.ts
@@ -3,6 +3,7 @@ import { LogLevel } from "../models";
 
 jest.mock("../helpers/log-support", () => ({
   consoleHas: jest.fn(() => [true, true, true, true, false]),
+  callbackHas: jest.fn(() => [true, true, true, true, false]),
 }));
 
 import { Logger } from "../logger-class";


### PR DESCRIPTION
Adds a new feature to the class constructor that allows a callback to be used instead of the `console`

This allows cloud loggers such as GCP the ability to take the structured JSON fro the server logging and add additional features compatible with the log store